### PR TITLE
langserver: add documentation strings to textDocument/hover

### DIFF
--- a/langserver/definition.go
+++ b/langserver/definition.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (h *LangHandler) handleDefinition(ctx context.Context, conn JSONRPC2Conn, req *jsonrpc2.Request, params lsp.TextDocumentPositionParams) ([]lsp.Location, error) {
-	fset, node, pkg, err := h.typecheck(ctx, conn, params.TextDocument.URI, params.Position)
+	fset, node, _, pkg, err := h.typecheck(ctx, conn, params.TextDocument.URI, params.Position)
 	if err != nil {
 		// Invalid nodes means we tried to click on something which is
 		// not an ident (eg comment/string/etc). Return no locations.

--- a/langserver/hover.go
+++ b/langserver/hover.go
@@ -1,18 +1,21 @@
 package langserver
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"go/ast"
 	"go/token"
 	"go/types"
+	"strings"
 
+	"github.com/slimsag/godocmd"
 	"github.com/sourcegraph/jsonrpc2"
 	"github.com/sourcegraph/sourcegraph-go/pkg/lsp"
 )
 
 func (h *LangHandler) handleHover(ctx context.Context, conn JSONRPC2Conn, req *jsonrpc2.Request, params lsp.TextDocumentPositionParams) (*lsp.Hover, error) {
-	fset, node, pkg, err := h.typecheck(ctx, conn, params.TextDocument.URI, params.Position)
+	fset, node, prog, pkg, err := h.typecheck(ctx, conn, params.TextDocument.URI, params.Position)
 	if err != nil {
 		// Invalid nodes means we tried to click on something which is
 		// not an ident (eg comment/string/etc). Return no information.
@@ -25,14 +28,15 @@ func (h *LangHandler) handleHover(ctx context.Context, conn JSONRPC2Conn, req *j
 	o := pkg.ObjectOf(node)
 	t := pkg.TypeOf(node)
 	if o == nil && t == nil {
+		comments := packageDoc(pkg.Files, node.Name)
+
 		// Package statement idents don't have an object, so try that separately.
 		if pkgName := packageStatementName(fset, pkg.Files, node); pkgName != "" {
 			return &lsp.Hover{
-				Contents: []lsp.MarkedString{{Language: "go", Value: "package " + pkgName}},
+				Contents: maybeAddComments(comments, []lsp.MarkedString{{Language: "go", Value: "package " + pkgName}}),
 				Range:    rangeForNode(fset, node),
 			}, nil
 		}
-
 		return nil, fmt.Errorf("type/object not found at %+v", params.Position)
 	}
 
@@ -57,8 +61,37 @@ func (h *LangHandler) handleHover(ctx context.Context, conn JSONRPC2Conn, req *j
 		s = types.TypeString(t, qf)
 	}
 
+	findComments := func(o types.Object) string {
+		// Package names must be resolved specially, so do this now to avoid
+		// additional overhead.
+		if v, ok := o.(*types.PkgName); ok {
+			return packageDoc(prog.Package(v.Imported().Path()).Files, node.Name)
+		}
+
+		// Resolve the object o into its respective ast.Node
+		_, path, _ := prog.PathEnclosingInterval(o.Pos(), o.Pos())
+		if path == nil {
+			return ""
+		}
+
+		// Pull the comment out of the comment map for the file.
+		f := path[len(path)-1].(*ast.File)
+		cmap := ast.NewCommentMap(fset, f, f.Comments)
+		pathIndex := 1
+		switch v := o.(type) {
+		case *types.Var:
+			if !v.IsField() {
+				pathIndex = 2
+			}
+		case *types.TypeName:
+			pathIndex = 2
+		}
+		return commentsToText(cmap[path[pathIndex]])
+	}
+
+	comments := findComments(o)
 	return &lsp.Hover{
-		Contents: []lsp.MarkedString{{Language: "go", Value: s}},
+		Contents: maybeAddComments(comments, []lsp.MarkedString{{Language: "go", Value: s}}),
 		Range:    rangeForNode(fset, node),
 	}, nil
 }
@@ -72,4 +105,43 @@ func packageStatementName(fset *token.FileSet, files []*ast.File, node *ast.Iden
 		}
 	}
 	return ""
+}
+
+// maybeAddComments appends the specified comments converted to Markdown godoc
+// form to the specified contents slice, if the comments string is not empty.
+func maybeAddComments(comments string, contents []lsp.MarkedString) []lsp.MarkedString {
+	if comments == "" {
+		return contents
+	}
+	var b bytes.Buffer
+	doc.ToMarkdown(&b, comments, nil)
+	return append(contents, lsp.MarkedString{
+		Language: "markdown",
+		Value:    b.String(),
+	})
+}
+
+// packageDoc finds the documentation for the named package from its files or
+// additional files.
+func packageDoc(files []*ast.File, pkgName string) string {
+	for _, f := range files {
+		if f.Name.Name == pkgName {
+			txt := f.Doc.Text()
+			if strings.TrimSpace(txt) != "" {
+				return txt
+			}
+		}
+	}
+	return ""
+}
+
+// commentsToText converts a slice of []*ast.CommentGroup to a flat string,
+// ensuring whitespace-only comment groups are dropped.
+func commentsToText(cgroups []*ast.CommentGroup) (text string) {
+	for _, c := range cgroups {
+		if strings.TrimSpace(c.Text()) != "" {
+			text += c.Text()
+		}
+	}
+	return text
 }

--- a/langserver/references.go
+++ b/langserver/references.go
@@ -20,7 +20,7 @@ import (
 )
 
 func (h *LangHandler) handleTextDocumentReferences(ctx context.Context, conn JSONRPC2Conn, req *jsonrpc2.Request, params lsp.ReferenceParams) ([]lsp.Location, error) {
-	fset, node, pkg, err := h.typecheck(ctx, conn, params.TextDocument.URI, params.Position)
+	fset, node, _, pkg, err := h.typecheck(ctx, conn, params.TextDocument.URI, params.Position)
 	if err != nil {
 		// Invalid nodes means we tried to click on something which is
 		// not an ident (eg comment/string/etc). Return no information.


### PR DESCRIPTION
This makes it such that hovering over any symbol always provides the
relevant documentation for that symbol.