### PR TITLE
Add HTTP basic auth docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Docker image `sourcegraph/lang-go` from Docker Hub.
 ### 🔐 Secure deployment 🔐
 
 If you have private code, we recommend deploying the language server behind an
-auth proxy (such as HTTP basic authentication below), a firewall, or a VPN.
+auth proxy (such as the example below using HTTP basic authentication in NGINX), a firewall, or a VPN.
 
 ### HTTP basic authentication
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Adding password for user langserveruser
 Add these to your Sourcegraph global settings:
 
 ```
-  "go.serverUrl": "ws://langserveruser:PASSWORD@host.docker.internal:4389/go",
+  "go.serverUrl": "ws://langserveruser:PASSWORD@host.docker.internal:7080/go",
   "go.sourcegraphUrl": "http://host.docker.internal:7080",
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,20 +30,6 @@ Re-type new password:
 Adding password for user langserveruser
 ```
 
-Add these to your Sourcegraph global settings:
-
-```
-  "go.serverUrl": "ws://langserveruser:PASSWORD@host.docker.internal:7080/go",
-  "go.sourcegraphUrl": "http://host.docker.internal:7080",
-```
-
-Fill in the `PASSWORD` that you created above.
-
-- If you're running on Linux, change `host.docker.internal` to the output of `ip addr show docker0 | grep -Po 'inet \K[\d.]+'`.
-- If you're not using the quickstart and are deploying elsewhere, change the settings so that:
-  - `go.serverUrl` is accessible from users' browsers
-  - `go.sourcegraphUrl` is the address of the Sourcegraph instance and is accessible from the Go language server
-
 Add a location directive the [nginx.conf](https://docs.sourcegraph.com/admin/nginx) that will route requests to the Go language server:
 
 ```nginx
@@ -69,11 +55,26 @@ http {
 }
 ```
 
-Again, change `host.docker.internal` depending on the deployment environment.
+- If you're running the quickstart on Linux, change `host.docker.internal` to the output of `ip addr show docker0 | grep -Po 'inet \K[\d.]+'`.
+- If you're using [Kubernetes](#using-kubernetes) (e.g. [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph)), change `host.docker.internal` to `lang-go`.
 
-Finally, restart the sourcegraph/server container to pick up the configuration change.
+Add these to your Sourcegraph global settings:
 
-After deploying the language server, unauthenticated access to `http://localhost:7080/go` should be blocked, but code intelligence should work when you're logged in.
+```
+  "go.serverUrl": "ws://langserveruser:PASSWORD@host.docker.internal:7080/go",
+  "go.sourcegraphUrl": "http://host.docker.internal:7080",
+```
+
+Fill in the `PASSWORD` that you created above.
+
+- If you're running the quickstart on Linux, change `host.docker.internal` to the output of `ip addr show docker0 | grep -Po 'inet \K[\d.]+'`.
+- If you're using [Kubernetes](#using-kubernetes) (e.g. [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph)):
+  - `go.serverUrl` is the address of the Go language server from the perspective of a user's browser (e.g. https://sourcegraph.example.com/go)
+  - `go.sourcegraphUrl` is the address of the Sourcegraph instance from the perspective of the Go language server (e.g. http://sourcegraph-frontend:30080)
+
+Finally, restart the sourcegraph/server container (or nginx deployment if deployed to Kubernetes) to pick up the configuration change.
+
+After deploying the language server, unauthenticated access to `http://localhost:7080/go` (or https://sourcegraph.example.com/go) should be blocked, but code intelligence should work when you're logged in.
 
 ### Using Docker
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Again, change `host.docker.internal` depending on the deployment environment.
 
 Finally, restart the sourcegraph/server container to pick up the configuration change.
 
-After deploying the language server, unauthenticated access to `http://localhohst:7080/go` should be blocked, but code intelligence should work when you're logged in.
+After deploying the language server, unauthenticated access to `http://localhost:7080/go` should be blocked, but code intelligence should work when you're logged in.
 
 ### Using Docker
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Finally, restart the sourcegraph/server container (or nginx deployment if deploy
 
 After deploying the language server, unauthenticated access to `http://localhost:7080/go` (or https://sourcegraph.example.com/go) should be blocked, but code intelligence should work when you're logged in.
 
+You can always revoke the `PASSWORD` by deleting the `.htpasswd` file and restarting nginx.
+
 ### Using Docker
 
 1. Run the Go language server:


### PR DESCRIPTION
The only wrinkle in using nginx for HTTP basic auth is that the request immediately following the WebSocket request to go-langserver results in a 401 (it happens to be a telemetry request):

![image](https://user-images.githubusercontent.com/1387653/53929894-3739cf00-4044-11e9-8276-e140f7965351.png)

The response is 401 from the Go frontend because I think nginx is also sending the basic auth to non-`/go` routes. I discovered this by noticing that the Network tab did not show basic auth, but the nginx access log did. Subsequent requests to non-`/go` routes do not have the basic auth added.

@keegancsmith Do you know why nginx seemingly attaches the basic auth defined in the `/go` location directive to the `/` location directive for the subsequent request?