### PR TITLE
support deactivation in language server mode

### DIFF
--- a/src/lang-go.ts
+++ b/src/lang-go.ts
@@ -647,8 +647,10 @@ export async function activateUsingWebSockets(ctx: sourcegraph.ExtensionContext)
         })
     )
 
+    // Implementations panel.
+    const IMPL_ID = 'go.impl' // implementations panel and provider ID
     ctx.subscriptions.add(
-        sourcegraph.languages.registerLocationProvider('id', [{ pattern: '*.go' }], {
+        sourcegraph.languages.registerLocationProvider(IMPL_ID, [{ pattern: '*.go' }], {
             provideLocations: async (doc: sourcegraph.TextDocument, pos: sourcegraph.Position) => {
                 const response = await sendDocPositionRequest({
                     doc,
@@ -660,6 +662,11 @@ export async function activateUsingWebSockets(ctx: sourcegraph.ExtensionContext)
             },
         })
     )
+    const panelView = sourcegraph.app.createPanelView(IMPL_ID)
+    panelView.title = 'Go ifaces/impls'
+    panelView.component = { locationProvider: IMPL_ID }
+    panelView.priority = 160
+    ctx.subscriptions.add(panelView)
 }
 
 function pathname(url: string): string {


### PR DESCRIPTION
Track the resources created by the extension so that it can be deactivated cleanly. Uses the pre-3.0 backcompat technique from https://docs.sourcegraph.com/extensions/authoring/activation#backcompat-for-sourcegraph-versions-prior-to-3-0 to avoid throwing an error on pre-3.0 versions of Sourcegraph.

This does not clean up the resources created in search mode (using basic code intel), but it's a start.