### PR TITLE
show Go ifaces/impls location provider in a panel

### DIFF
--- a/src/lang-go.ts
+++ b/src/lang-go.ts
@@ -647,8 +647,10 @@ export async function activateUsingWebSockets(ctx: sourcegraph.ExtensionContext)
         })
     )
 
+    // Implementations panel.
+    const IMPL_ID = 'go.impl' // implementations panel and provider ID
     ctx.subscriptions.add(
-        sourcegraph.languages.registerLocationProvider('id', [{ pattern: '*.go' }], {
+        sourcegraph.languages.registerLocationProvider(IMPL_ID, [{ pattern: '*.go' }], {
             provideLocations: async (doc: sourcegraph.TextDocument, pos: sourcegraph.Position) => {
                 const response = await sendDocPositionRequest({
                     doc,
@@ -660,6 +662,11 @@ export async function activateUsingWebSockets(ctx: sourcegraph.ExtensionContext)
             },
         })
     )
+    const panelView = sourcegraph.app.createPanelView(IMPL_ID)
+    panelView.title = 'Go ifaces/impls'
+    panelView.component = { locationProvider: IMPL_ID }
+    panelView.priority = 160
+    ctx.subscriptions.add(panelView)
 }
 
 function pathname(url: string): string {


### PR DESCRIPTION
Previously, the call to `registerLocationProvider('id', ...` was a noop. The location provider was not actually used anywhere. It needs to be added to a panel to be shown.

- Depends on https://github.com/sourcegraph/sourcegraph/pull/2733
- Depends on #46 

![goifaceimpls](https://user-images.githubusercontent.com/1976/54329595-86957780-45cf-11e9-91fe-17f0b2392290.png)

Unlike for TypeScript (see note in https://github.com/sourcegraph/sourcegraph-typescript/pull/132), Go ifaces/impls were already broken, so this should be merged immediately even though https://github.com/sourcegraph/sourcegraph/pull/2733 is not yet merged and released.