### PR TITLE
hide panel/toolbar actions on irrelevant panels

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,11 +51,12 @@
     "menus": {
       "panel/toolbar": [
         {
-          "action": "externalReferences.toggle"
+          "action": "externalReferences.toggle",
+          "when": "panel.activeView.id == 'references'"
         },
         {
           "action": "impreciseResults",
-          "when": "isImprecise"
+          "when": "isImprecise && panel.activeView.hasLocations"
         }
       ]
     },


### PR DESCRIPTION
The "References: Search mode" and "Show results from other repositories" actions were showing up on other panels, such as Git history and (if enabled) code discussions. This makes it so they only show up on the appropriate panels.

![image](https://user-images.githubusercontent.com/1976/54484976-fa34c000-482d-11e9-89f3-44b8beee5922.png)
