### PR TITLE
Filter definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "typescript": "^3.1.6"
   },
   "dependencies": {
-    "@sourcegraph/basic-code-intel": "6.0.7",
+    "@sourcegraph/basic-code-intel": "6.0.9",
     "@sourcegraph/vscode-ws-jsonrpc": "0.0.3-fork",
     "prettier": "^1.16.4",
     "rxjs": "^6.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -700,14 +700,15 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
-"@sourcegraph/basic-code-intel@6.0.7":
-  version "6.0.7"
-  resolved "https://registry.yarnpkg.com/@sourcegraph/basic-code-intel/-/basic-code-intel-6.0.7.tgz#6ba8623c1c5e71f780a059ccea2120ffdc1e3600"
-  integrity sha512-+amGIq54N3aVOj7AxNtW6QtDfUVvtT253Ha+i9sofyo217L/7Ucwo/WoDGuded9Ng9FUxUM6UOS3MREW+lkUGQ==
+"@sourcegraph/basic-code-intel@6.0.9":
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/@sourcegraph/basic-code-intel/-/basic-code-intel-6.0.9.tgz#7c76513a5cda622e86e966a5dd4128be677278bc"
+  integrity sha512-/pfZ1E8mhetl3wOVAD3nn8DfQoQHE+PzvezzPXF3P+sSZyn7p4oHErn+ezo4gR3d7UwjZ4UEn0UkbSdW5RWjnw==
   dependencies:
     lodash "^4.17.11"
     rxjs "^6.3.3"
     sourcegraph "^23.0.0"
+    sprintf-js "^1.1.2"
 
 "@sourcegraph/prettierrc@^2.2.0":
   version "2.2.0"
@@ -5154,6 +5155,11 @@ split-string@^3.0.1, split-string@^3.0.2:
   integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
   dependencies:
     extend-shallow "^3.0.0"
+
+sprintf-js@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.2.tgz#da1765262bf8c0f571749f2ad6c26300207ae673"
+  integrity sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==
 
 sprintf-js@~1.0.2:
   version "1.0.3"


### PR DESCRIPTION
This uses a regex to find import statements and omits symbol search results that are defined in files that are not imported.

![image](https://user-images.githubusercontent.com/1387653/54734197-28cad780-4b5b-11e9-85f2-424668f6243e.png)

Here's an example where this technique successfully filtered down from ~20 results to a single unique result:

![image](https://user-images.githubusercontent.com/1387653/54734301-ccb48300-4b5b-11e9-99e7-c3ecb4be67bc.png)

Where this breaks: if the real definition of the token is in a transitively imported package, this will incorrectly omit the result from the list unless there were no results in imported packages. One way to solve that is to walk the imports, but that would be quite slow. Maybe we can index the set of transitive imports somehow so that lookups are fast.