### PR TITLE
fix issue where usages in a subpackage would be ignored

### DIFF
--- a/src/lang-go.ts
+++ b/src/lang-go.ts
@@ -320,10 +320,16 @@ async function repositoriesThatImportViaGDDO(
         const repoNames: string[] = (await Promise.all(
             response.results
                 .map(result => result.path)
-                .filter(repo =>
+                .filter(path =>
                     // This helps filter out repos that do not exist on the Sourcegraph.com instance
-                    repo.startsWith('github.com/')
+                    path.startsWith('github.com/')
                 )
+                .map(path => {
+                    // Chop off portion after "github.com/owner/repo".
+                    const parts = path.split('/')
+                    return parts.slice(0, 3).join('/')
+                })
+                .filter(repo => !!repo)
                 .slice(0, limit)
                 .map(async repo => {
                     try {


### PR DESCRIPTION
If a package was imported by a subpackage of a repository, the extension would try to look up the subpackage's import path as a repository name. For example, it would try to look up the repository named `github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend` at https://sourcegraph.com/github.com/sourcegraph/go-diff/-/blob/diff/print.go#L13:6&tab=references. This led to an error "Unable to find cross-repository references in ${repo}, probably because the repository was renamed and Sourcegraph does not support renamed repositories yet" that was erroneous.

This fix chops off portions of the import path that are beyond the `github.com/owner/repo` name.