### PR TITLE
Fall back to basic-code-intel after 500ms

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
   "dependencies": {
     "@sourcegraph/basic-code-intel": "6.0.10",
     "@sourcegraph/vscode-ws-jsonrpc": "0.0.3-fork",
+    "path-browserify": "^1.0.0",
     "prettier": "^1.16.4",
     "rxjs": "^6.3.3",
     "sourcegraph-langserver-http": "https://github.com/sourcegraph/sourcegraph-langserver-http#0b0173feef37d1f4f68d881c95ac3f4c97bfedb3",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "typescript": "^3.1.6"
   },
   "dependencies": {
-    "@sourcegraph/basic-code-intel": "6.0.10",
+    "@sourcegraph/basic-code-intel": "6.0.14",
     "@sourcegraph/vscode-ws-jsonrpc": "0.0.3-fork",
     "path-browserify": "^1.0.0",
     "prettier": "^1.16.4",

--- a/src/lang-go.ts
+++ b/src/lang-go.ts
@@ -233,8 +233,6 @@ async function connectAndInitialize(
         }
     )
 
-    console.log('Language server initialized ✅')
-
     connection.sendNotification(lsp.InitializedNotification.type)
 
     return connection

--- a/yarn.lock
+++ b/yarn.lock
@@ -700,15 +700,14 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
-"@sourcegraph/basic-code-intel@6.0.10":
-  version "6.0.10"
-  resolved "https://registry.yarnpkg.com/@sourcegraph/basic-code-intel/-/basic-code-intel-6.0.10.tgz#93ce193bb45ba4013a8d6c4cdb8059f10e8e0d24"
-  integrity sha512-yOXM1gQCjn/xOq4rcSJ714gFKxHEuhNeexuhx6Qi+cciV+7SB+NJhAJvR395NvC+ZMQpYqDvnvFcSwpesBbcEw==
+"@sourcegraph/basic-code-intel@6.0.14":
+  version "6.0.14"
+  resolved "https://registry.yarnpkg.com/@sourcegraph/basic-code-intel/-/basic-code-intel-6.0.14.tgz#898216e8966d1b902c5e49199a2a33d255ed9de4"
+  integrity sha512-SekYreQAgpmeE4oNWh+Dke6ChXwudLyr+5qU79DX6lSQY1UQLg55T5cmwSbcIBLKwQzvyyUJ7YLvtQhXOn7QwA==
   dependencies:
     lodash "^4.17.11"
     rxjs "^6.3.3"
     sourcegraph "^23.0.0"
-    sprintf-js "^1.1.2"
 
 "@sourcegraph/prettierrc@^2.2.0":
   version "2.2.0"
@@ -5114,11 +5113,6 @@ split-string@^3.0.1, split-string@^3.0.2:
   integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
   dependencies:
     extend-shallow "^3.0.0"
-
-sprintf-js@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.2.tgz#da1765262bf8c0f571749f2ad6c26300207ae673"
-  integrity sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==
 
 sprintf-js@~1.0.2:
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2371,7 +2371,7 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
-glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.3:
+glob@^7.0.3, glob@^7.1.1, glob@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
@@ -3834,6 +3834,11 @@ path-browserify@0.0.0:
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
   integrity sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=
 
+path-browserify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.0.tgz#40702a97af46ae00b0ea6fa8998c0b03c0af160d"
+  integrity sha512-Hkavx/nY4/plImrZPHRk2CL9vpOymZLgEbMNX1U0bjcBL7QN9wODxyx0yaMZURSQaUtSEvDrfAvxa9oPb0at9g==
+
 path-dirname@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
@@ -3866,7 +3871,7 @@ path-key@^2.0.0, path-key@^2.0.1:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
-path-parse@^1.0.5, path-parse@^1.0.6:
+path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==


### PR DESCRIPTION
Here's what it looks like (the console logs were only for making this GIF):

![2019-03-26 23 03 08](https://user-images.githubusercontent.com/1387653/55054111-c4f15480-501b-11e9-8bf0-66812a1edde4.gif)

The language server request gets kicked off immediately. If it doesn't respond in less than 500ms, basic code intel gets kicked off. Whichever responds first wins, and the other is ignored until the next hover/def/ref call.

Depends on https://github.com/sourcegraph/sourcegraph-basic-code-intel/pull/82