### PR TITLE
Recommend -freeosmemory=false

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ You can always revoke the `PASSWORD` by deleting the `.htpasswd` file and restar
 
     ```sh
     docker run --rm --name lang-go -p 4389:4389 sourcegraph/lang-go \
-      go-langserver -mode=websocket -addr=:4389 -usebuildserver -usebinarypkgcache=false
+      go-langserver -mode=websocket -addr=:4389 -usebuildserver -usebinarypkgcache=false -freeosmemory=false
     ```
 
     You can verify it's up and running with [`ws`](https://github.com/hashrocket/ws) (run this from the same machine your browser is running on):
@@ -171,6 +171,7 @@ spec:
         - -usebuildserver
         - -usebinarypkgcache=false
         - -cachedir=$(CACHE_DIR)
+        - -freeosmemory=false
         env:
         - name: LIGHTSTEP_ACCESS_TOKEN
           value: '???'


### PR DESCRIPTION
Without `-freeosmemory=false`, you'll see spikes in CPU usage:

![image (11)](https://user-images.githubusercontent.com/1387653/55118910-2d3c4680-50ad-11e9-96cf-967821c2841b.png)

See https://sourcegraph.slack.com/archives/C07KZF47K/p1553725632436300

cc @ryan-blunden 