### PR TITLE
Fix withFallback to emit from main even if fallback has emitted

### DIFF
--- a/src/lang-go.ts
+++ b/src/lang-go.ts
@@ -22,6 +22,7 @@ import {
     combineLatest,
     ObservableInput,
     merge,
+    timer,
 } from 'rxjs'
 import {
     concatMap,
@@ -557,12 +558,14 @@ function withFallback<T>({
     fallback: ObservableInput<T>
     delayMilliseconds: number
 }): Observable<T> {
-    return race(
-        of(null).pipe(switchMap(() => from(main))),
+    const mainObservable = from(main).pipe(share())
+    return merge(
         of(null).pipe(
             delay(delayMilliseconds),
-            switchMap(() => from(fallback))
-        )
+            switchMap(() => from(fallback)),
+            takeUntil(mainObservable)
+        ),
+        mainObservable
     )
 }
 


### PR DESCRIPTION
Fixes sourcegraph/sourcegraph#3039

`withFallback()` used `rxjs.race()` to fallback to basic-code-intel if the language server had not emitted after 500ms. The problem is that `race()` works as follows:

> The observable to emit first is used.

This is an issue when pinning the hover tooltip, because if the basic-code-intel result is used first, the language server result will *never be used*.