### PR TITLE
Disable fallback (will bring it back feature-flagged)

### DIFF
--- a/src/lang-go.ts
+++ b/src/lang-go.ts
@@ -557,13 +557,14 @@ function withFallback<T>({
     fallback: ObservableInput<T>
     delayMilliseconds: number
 }): Observable<T> {
-    return race(
-        of(null).pipe(switchMap(() => from(main))),
-        of(null).pipe(
-            delay(delayMilliseconds),
-            switchMap(() => from(fallback))
-        )
-    )
+    return from(main)
+    // return race(
+    //     of(null).pipe(switchMap(() => from(main))),
+    //     of(null).pipe(
+    //         delay(delayMilliseconds),
+    //         switchMap(() => from(fallback))
+    //     )
+    // )
 }
 
 /**


### PR DESCRIPTION
> No need for review, this will be brought back and feature flagged.

@lguychard This will unblock you immediately, and we can figure out what to do about `withFallback` later in https://github.com/sourcegraph/sourcegraph-go/pull/57