### PR TITLE
Revert fallback to basic-code-intel

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,9 +121,8 @@
     "typescript": "^3.1.6"
   },
   "dependencies": {
-    "@sourcegraph/basic-code-intel": "6.0.14",
+    "@sourcegraph/basic-code-intel": "6.0.10",
     "@sourcegraph/vscode-ws-jsonrpc": "0.0.3-fork",
-    "path-browserify": "^1.0.0",
     "prettier": "^1.16.4",
     "rxjs": "^6.3.3",
     "sourcegraph-langserver-http": "https://github.com/sourcegraph/sourcegraph-langserver-http#0b0173feef37d1f4f68d881c95ac3f4c97bfedb3",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "typescript": "^3.1.6"
   },
   "dependencies": {
-    "@sourcegraph/basic-code-intel": "6.0.10",
+    "@sourcegraph/basic-code-intel": "6.0.14",
     "@sourcegraph/vscode-ws-jsonrpc": "0.0.3-fork",
     "prettier": "^1.16.4",
     "rxjs": "^6.3.3",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "typescript": "^3.1.6"
   },
   "dependencies": {
-    "@sourcegraph/basic-code-intel": "6.0.14",
+    "@sourcegraph/basic-code-intel": "6.0.15",
     "@sourcegraph/vscode-ws-jsonrpc": "0.0.3-fork",
     "prettier": "^1.16.4",
     "rxjs": "^6.3.3",

--- a/src/lang-go.ts
+++ b/src/lang-go.ts
@@ -1,6 +1,6 @@
 import '@babel/polyfill'
 
-import * as basicCodeIntel from '@sourcegraph/basic-code-intel'
+import { activateBasicCodeIntel } from '@sourcegraph/basic-code-intel'
 import * as wsrpc from '@sourcegraph/vscode-ws-jsonrpc'
 import { ajax } from 'rxjs/ajax'
 import * as sourcegraph from 'sourcegraph'
@@ -10,19 +10,7 @@ import * as convert from './convert-lsp-to-sea'
 import * as lspext from './lspext'
 
 import * as path from 'path'
-
-import {
-    BehaviorSubject,
-    from,
-    Observable,
-    Observer,
-    of,
-    throwError,
-    race,
-    combineLatest,
-    ObservableInput,
-    merge,
-} from 'rxjs'
+import { BehaviorSubject, from, Observable, Observer, of, throwError } from 'rxjs'
 import {
     concatMap,
     distinctUntilChanged,
@@ -33,20 +21,11 @@ import {
     switchMap,
     take,
     finalize,
-    tap,
-    delay,
-    mapTo,
-    startWith,
-    takeUntil,
-    share,
-    filter,
-    endWith,
 } from 'rxjs/operators'
 
 import { ConsoleLogger, createWebSocketConnection } from '@sourcegraph/vscode-ws-jsonrpc'
 import gql from 'tagged-template-noop'
 import { Settings } from './settings'
-import { documentSelector } from '@sourcegraph/basic-code-intel/lib/handler'
 
 // If we can rid ourselves of file:// URIs, this type won't be necessary and we
 // can use lspext.Xreference directly.
@@ -547,34 +526,9 @@ function positionParams(doc: sourcegraph.TextDocument, pos: sourcegraph.Position
 }
 
 /**
- * Emits from `fallback` after `delayMilliseconds`. Useful for falling back to
- * basic-code-intel while the language server is running.
- */
-function withFallback<T>({
-    main,
-    fallback,
-    delayMilliseconds,
-}: {
-    main: ObservableInput<T>
-    fallback: ObservableInput<T>
-    delayMilliseconds: number
-}): Observable<T> {
-    return race(
-        of(null).pipe(switchMap(() => from(main))),
-        of(null).pipe(
-            delay(delayMilliseconds),
-            switchMap(() => from(fallback))
-        )
-    )
-}
-
-/**
  * Uses WebSockets to communicate with a language server.
  */
-export async function activateUsingWebSockets(
-    ctx: sourcegraph.ExtensionContext,
-    basicCodeIntelHandler: basicCodeIntel.Handler
-): Promise<void> {
+export async function activateUsingWebSockets(ctx: sourcegraph.ExtensionContext): Promise<void> {
     const accessToken = await getOrTryToCreateAccessToken()
     const settings: BehaviorSubject<Settings> = new BehaviorSubject<Settings>({})
     ctx.subscriptions.add(
@@ -625,55 +579,38 @@ export async function activateUsingWebSockets(
 
     ctx.subscriptions.add(
         sourcegraph.languages.registerHoverProvider([{ pattern: '*.go' }], {
-            provideHover: (doc: sourcegraph.TextDocument, pos: sourcegraph.Position) =>
-                withFallback({
-                    main: sendDocPositionRequest({ doc, pos, ty: lsp.HoverRequest.type, useCache: true }).then(
-                        convert.hover
-                    ),
-                    fallback: basicCodeIntelHandler.hover(doc, pos),
-                    delayMilliseconds: 500,
-                }),
+            provideHover: async (doc: sourcegraph.TextDocument, pos: sourcegraph.Position) => {
+                const response = await sendDocPositionRequest({ doc, pos, ty: lsp.HoverRequest.type, useCache: true })
+                return convert.hover(response)
+            },
         })
     )
 
     ctx.subscriptions.add(
         sourcegraph.languages.registerDefinitionProvider([{ pattern: '*.go' }], {
-            provideDefinition: (doc: sourcegraph.TextDocument, pos: sourcegraph.Position) =>
-                withFallback({
-                    main: sendDocPositionRequest({
-                        doc,
-                        pos,
-                        ty: new lsp.RequestType<any, any, any, void>('textDocument/xdefinition') as any,
-                        useCache: true,
-                    }).then(response => convert.xdefinition({ currentDocURI: doc.uri, xdefinition: response })),
-                    fallback: basicCodeIntelHandler.definition(doc, pos),
-                    delayMilliseconds: 500,
-                }),
+            provideDefinition: async (doc: sourcegraph.TextDocument, pos: sourcegraph.Position) => {
+                const response = await sendDocPositionRequest({
+                    doc,
+                    pos,
+                    ty: new lsp.RequestType<any, any, any, void>('textDocument/xdefinition') as any,
+                    useCache: true,
+                })
+                return convert.xdefinition({ currentDocURI: doc.uri, xdefinition: response })
+            },
         })
     )
 
     ctx.subscriptions.add(
         sourcegraph.languages.registerReferenceProvider([{ pattern: '*.go' }], {
-            provideReferences: (doc: sourcegraph.TextDocument, pos: sourcegraph.Position) =>
-                withFallback({
-                    main: sendDocPositionRequest({
-                        doc,
-                        pos,
-                        ty: lsp.ReferencesRequest.type,
-                        useCache: true,
-                    }).then(response => ({
-                        kind: 'main',
-                        result: convert.references({ currentDocURI: doc.uri, references: response }),
-                    })),
-                    fallback: basicCodeIntelHandler.references(doc, pos).then(result => ({ kind: 'fallback', result })),
-                    delayMilliseconds: 2000,
-                }).pipe(
-                    // Indicate in the UI that the results are imprecise
-                    tap(({ kind }) => {
-                        sourcegraph.internal.updateContext({ isImprecise: kind === 'fallback' })
-                    }),
-                    map(({ result }) => result)
-                ),
+            provideReferences: async (doc: sourcegraph.TextDocument, pos: sourcegraph.Position) => {
+                const response = await sendDocPositionRequest({
+                    doc,
+                    pos,
+                    ty: lsp.ReferencesRequest.type,
+                    useCache: true,
+                })
+                return convert.references({ currentDocURI: doc.uri, references: response })
+            },
         })
     )
 
@@ -759,61 +696,45 @@ function pathname(url: string): string {
     return pathname
 }
 
-const basicCodeIntelHandlerArgs: basicCodeIntel.HandlerArgs = {
-    sourcegraph,
-    languageID: 'go',
-    fileExts: ['go'],
-    filterDefinitions: ({ repo, filePath, fileContent, results }) => {
-        const currentFileImportedPaths = fileContent
-            .split('\n')
-            .map(line => {
-                // Matches the import at index 3
-                const match = /^(import |\t)(\w+ |\. )?"(.*)"$/.exec(line)
-                return match ? match[3] : undefined
-            })
-            .filter((x): x is string => Boolean(x))
-
-        const currentFileImportPath = repo + '/' + path.dirname(filePath)
-
-        const filteredResults = results.filter(result => {
-            const resultImportPath = result.repo + '/' + path.dirname(result.file)
-            return [...currentFileImportedPaths, currentFileImportPath].some(i => resultImportPath === i)
-        })
-
-        return filteredResults.length === 0 ? results : filteredResults
-    },
-    commentStyle: {
-        lineRegex: /\/\/\s?/,
-    },
-}
-
 // No-op for Sourcegraph versions prior to 3.0.
 const DUMMY_CTX = { subscriptions: { add: (_unsubscribable: any) => void 0 } }
 
 export function activate(ctx: sourcegraph.ExtensionContext = DUMMY_CTX): void {
     async function afterActivate(): Promise<void> {
-        const basicCodeIntelHandler = new basicCodeIntel.Handler(basicCodeIntelHandlerArgs)
         const address = sourcegraph.configuration.get<Settings>().get('go.serverUrl')
         if (address) {
-            await activateUsingWebSockets(ctx, basicCodeIntelHandler)
+            await activateUsingWebSockets(ctx)
         } else {
-            sourcegraph.internal.updateContext({ isImprecise: true })
+            activateBasicCodeIntel({
+                sourcegraph,
+                languageID: 'go',
+                fileExts: ['go'],
+                filterDefinitions: ({ repo, filePath, pos, fileContent, results }) => {
+                    const currentFileImportedPaths = fileContent
+                        .split('\n')
+                        .map(line => {
+                            // Matches the import at index 3
+                            const match = /^(import |\t)(\w+ |\. )?"(.*)"$/.exec(line)
+                            return match ? match[3] : undefined
+                        })
+                        .filter((x): x is string => Boolean(x))
 
-            ctx.subscriptions.add(
-                sourcegraph.languages.registerHoverProvider(documentSelector(basicCodeIntelHandler.fileExts), {
-                    provideHover: (doc, pos) => basicCodeIntelHandler.hover(doc, pos),
-                })
-            )
-            ctx.subscriptions.add(
-                sourcegraph.languages.registerDefinitionProvider(documentSelector(basicCodeIntelHandler.fileExts), {
-                    provideDefinition: (doc, pos) => basicCodeIntelHandler.definition(doc, pos),
-                })
-            )
-            ctx.subscriptions.add(
-                sourcegraph.languages.registerReferenceProvider(documentSelector(basicCodeIntelHandler.fileExts), {
-                    provideReferences: (doc, pos) => basicCodeIntelHandler.references(doc, pos),
-                })
-            )
+                    const currentFileImportPath = repo + '/' + path.dirname(filePath)
+
+                    const filteredResults = results.filter(result => {
+                        const resultImportPath = result.repo + '/' + path.dirname(result.file)
+                        return (
+                            currentFileImportedPaths.some(i => resultImportPath.includes(i)) ||
+                            resultImportPath === currentFileImportPath
+                        )
+                    })
+
+                    return filteredResults.length === 0 ? results : filteredResults
+                },
+                commentStyle: {
+                    lineRegex: /\/\/\s?/,
+                },
+            })(ctx)
         }
     }
     setTimeout(afterActivate, 100)

--- a/src/lang-go.ts
+++ b/src/lang-go.ts
@@ -559,14 +559,13 @@ function withFallback<T>({
     fallback: ObservableInput<T>
     delayMilliseconds: number
 }): Observable<T> {
-    return from(main)
-    // return race(
-    //     of(null).pipe(switchMap(() => from(main))),
-    //     of(null).pipe(
-    //         delay(delayMilliseconds),
-    //         switchMap(() => from(fallback))
-    //     )
-    // )
+    return race(
+        of(null).pipe(switchMap(() => from(main))),
+        of(null).pipe(
+            delay(delayMilliseconds),
+            switchMap(() => from(fallback))
+        )
+    )
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -700,14 +700,15 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
-"@sourcegraph/basic-code-intel@6.0.14":
-  version "6.0.14"
-  resolved "https://registry.yarnpkg.com/@sourcegraph/basic-code-intel/-/basic-code-intel-6.0.14.tgz#898216e8966d1b902c5e49199a2a33d255ed9de4"
-  integrity sha512-SekYreQAgpmeE4oNWh+Dke6ChXwudLyr+5qU79DX6lSQY1UQLg55T5cmwSbcIBLKwQzvyyUJ7YLvtQhXOn7QwA==
+"@sourcegraph/basic-code-intel@6.0.10":
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/@sourcegraph/basic-code-intel/-/basic-code-intel-6.0.10.tgz#93ce193bb45ba4013a8d6c4cdb8059f10e8e0d24"
+  integrity sha512-yOXM1gQCjn/xOq4rcSJ714gFKxHEuhNeexuhx6Qi+cciV+7SB+NJhAJvR395NvC+ZMQpYqDvnvFcSwpesBbcEw==
   dependencies:
     lodash "^4.17.11"
     rxjs "^6.3.3"
     sourcegraph "^23.0.0"
+    sprintf-js "^1.1.2"
 
 "@sourcegraph/prettierrc@^2.2.0":
   version "2.2.0"
@@ -3833,11 +3834,6 @@ path-browserify@0.0.0:
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
   integrity sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=
 
-path-browserify@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.0.tgz#40702a97af46ae00b0ea6fa8998c0b03c0af160d"
-  integrity sha512-Hkavx/nY4/plImrZPHRk2CL9vpOymZLgEbMNX1U0bjcBL7QN9wODxyx0yaMZURSQaUtSEvDrfAvxa9oPb0at9g==
-
 path-dirname@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
@@ -5113,6 +5109,11 @@ split-string@^3.0.1, split-string@^3.0.2:
   integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
   dependencies:
     extend-shallow "^3.0.0"
+
+sprintf-js@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.2.tgz#da1765262bf8c0f571749f2ad6c26300207ae673"
+  integrity sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==
 
 sprintf-js@~1.0.2:
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -700,15 +700,14 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
-"@sourcegraph/basic-code-intel@6.0.10":
-  version "6.0.10"
-  resolved "https://registry.yarnpkg.com/@sourcegraph/basic-code-intel/-/basic-code-intel-6.0.10.tgz#93ce193bb45ba4013a8d6c4cdb8059f10e8e0d24"
-  integrity sha512-yOXM1gQCjn/xOq4rcSJ714gFKxHEuhNeexuhx6Qi+cciV+7SB+NJhAJvR395NvC+ZMQpYqDvnvFcSwpesBbcEw==
+"@sourcegraph/basic-code-intel@6.0.14":
+  version "6.0.14"
+  resolved "https://registry.yarnpkg.com/@sourcegraph/basic-code-intel/-/basic-code-intel-6.0.14.tgz#898216e8966d1b902c5e49199a2a33d255ed9de4"
+  integrity sha512-SekYreQAgpmeE4oNWh+Dke6ChXwudLyr+5qU79DX6lSQY1UQLg55T5cmwSbcIBLKwQzvyyUJ7YLvtQhXOn7QwA==
   dependencies:
     lodash "^4.17.11"
     rxjs "^6.3.3"
     sourcegraph "^23.0.0"
-    sprintf-js "^1.1.2"
 
 "@sourcegraph/prettierrc@^2.2.0":
   version "2.2.0"
@@ -5109,11 +5108,6 @@ split-string@^3.0.1, split-string@^3.0.2:
   integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
   dependencies:
     extend-shallow "^3.0.0"
-
-sprintf-js@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.2.tgz#da1765262bf8c0f571749f2ad6c26300207ae673"
-  integrity sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==
 
 sprintf-js@~1.0.2:
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -700,10 +700,10 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
-"@sourcegraph/basic-code-intel@6.0.14":
-  version "6.0.14"
-  resolved "https://registry.yarnpkg.com/@sourcegraph/basic-code-intel/-/basic-code-intel-6.0.14.tgz#898216e8966d1b902c5e49199a2a33d255ed9de4"
-  integrity sha512-SekYreQAgpmeE4oNWh+Dke6ChXwudLyr+5qU79DX6lSQY1UQLg55T5cmwSbcIBLKwQzvyyUJ7YLvtQhXOn7QwA==
+"@sourcegraph/basic-code-intel@6.0.15":
+  version "6.0.15"
+  resolved "https://registry.yarnpkg.com/@sourcegraph/basic-code-intel/-/basic-code-intel-6.0.15.tgz#b7c0baa894d89244fc5155a08839543cdbcca4ea"
+  integrity sha512-oMNbyAar7Sy4gnX5hLXQZhmLFy19zFtKndkJ4BlLCvRsmuJozMgWT32sUnhpDrco32NJQf6Irgl7a7PFX1Gb5w==
   dependencies:
     lodash "^4.17.11"
     rxjs "^6.3.3"


### PR DESCRIPTION
> No need for review, this doesn't change any behavior.

Reverts https://github.com/sourcegraph/sourcegraph-go/pull/58
Reverts https://github.com/sourcegraph/sourcegraph-go/pull/55

Before the fallback to basic-code-intel gets added back in https://github.com/sourcegraph/sourcegraph-go/pull/57, more user research needs to be done because the `race()` implementation got negative feedback.