### PR TITLE
Fix same-repo exclusion

### DIFF
--- a/src/lang-go.ts
+++ b/src/lang-go.ts
@@ -274,7 +274,7 @@ function rootURIFromDoc(doc: sourcegraph.TextDocument): URL {
 
 function repoNameFromDoc(doc: sourcegraph.TextDocument): string {
     const url = new URL(doc.uri)
-    return url.pathname.slice(2)
+    return path.join(url.hostname, url.pathname.slice(1))
 }
 
 /**


### PR DESCRIPTION
Fixes https://sourcegraph.slack.com/archives/CHXHX7XAS/p1556931462002400

Fixes a problem where the same repository would be searched for cross-repo references, resulting in duplicate and/or stale references.