### PR TITLE
Bump basic-code-intel to 7.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "typescript": "^3.1.6"
   },
   "dependencies": {
-    "@sourcegraph/basic-code-intel": "7.0.6",
+    "@sourcegraph/basic-code-intel": "7.0.7",
     "@sourcegraph/lsp-client": "^2.0.0-beta.2",
     "@sourcegraph/vscode-ws-jsonrpc": "0.0.3-fork",
     "prettier": "^1.16.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -700,10 +700,10 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
-"@sourcegraph/basic-code-intel@7.0.6":
-  version "7.0.6"
-  resolved "https://registry.yarnpkg.com/@sourcegraph/basic-code-intel/-/basic-code-intel-7.0.6.tgz#ad7b747cbea21d089447eb327afc2fb402dade3e"
-  integrity sha512-gK1ayb4vSD3SEJdnQqG7VGilFjl6naQ1JvrQNrbUiI4zQfoN7HfsBhWNtThHM5PfLkKBpyEnqyrFqB6E5FmZrA==
+"@sourcegraph/basic-code-intel@7.0.7":
+  version "7.0.7"
+  resolved "https://registry.yarnpkg.com/@sourcegraph/basic-code-intel/-/basic-code-intel-7.0.7.tgz#fea7317578d0bb32e712361d5147c4df674d5c0b"
+  integrity sha512-SU0D8isrBxamwS3hc5swI5LYv0jFwNwuYZJE+9gYFgHUKz4BS5YIoOsxjehDNcmcUmboNadr9Iw1THpVZyQXDg==
   dependencies:
     lodash "^4.17.11"
     rxjs "^6.3.3"


### PR DESCRIPTION
Includes https://github.com/sourcegraph/sourcegraph-basic-code-intel/pull/160