### PR TITLE
Fallback from LSIF to others

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "typescript": "^3.1.6"
   },
   "dependencies": {
-    "@sourcegraph/basic-code-intel": "7.0.9",
+    "@sourcegraph/basic-code-intel": "7.0.10",
     "@sourcegraph/lsp-client": "^2.0.0-beta.2",
     "@sourcegraph/vscode-ws-jsonrpc": "0.0.3-fork",
     "prettier": "^1.16.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -700,10 +700,10 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
-"@sourcegraph/basic-code-intel@7.0.9":
-  version "7.0.9"
-  resolved "https://registry.yarnpkg.com/@sourcegraph/basic-code-intel/-/basic-code-intel-7.0.9.tgz#b137eac5fce738eaa739422d2c3d67ccc6a890e0"
-  integrity sha512-z/grKdwm33Zxf+UXgnbnHtE5dhTk53UFyTAQhNPzvAzCYhLbLEcjN6YxH2M3f4tmXH/XIwXzhS0VlkliBXqkeg==
+"@sourcegraph/basic-code-intel@7.0.10":
+  version "7.0.10"
+  resolved "https://registry.yarnpkg.com/@sourcegraph/basic-code-intel/-/basic-code-intel-7.0.10.tgz#26d1af33f48075199e4ec0ca1cb53d64bdcb162f"
+  integrity sha512-lZNd90AJFRJIQM2V8tzxzVlXPRQMrdIJ81T8vzGKXPwRjkT+Qr4mCqoRJKERL6J3OOcb9ElfQ3KwzSNvawwL2g==
   dependencies:
     lodash "^4.17.11"
     rxjs "^6.3.3"


### PR DESCRIPTION
This pulls in https://github.com/sourcegraph/sourcegraph-basic-code-intel/pull/179 for fallback because LSIF data might be sparse.

For references: if LSP is enabled, then use that exclusively.