### PR TITLE
Drop fuzzy results from files that have LSIF results

### DIFF
--- a/src/lang-go.ts
+++ b/src/lang-go.ts
@@ -836,11 +836,22 @@ export function activate(ctx: sourcegraph.ExtensionContext = DUMMY_CTX): void {
                         return references ? references.value : null
                     }
 
+                    // Gets an opaque value that is the same for all locations
+                    // within a file but different from other files.
+                    const file = (loc: sourcegraph.Location) => `${loc.uri.host} ${loc.uri.pathname} ${loc.uri.hash}`
+
                     // Concatenates LSIF results (if present) with fuzzy results
                     // because LSIF data might be sparse.
                     const lsifReferences = await lsif.references(doc, pos)
                     const fuzzyReferences = (await basicCodeIntel.references(doc, pos)) || []
-                    return [...(lsifReferences === undefined ? [] : lsifReferences.value), ...fuzzyReferences]
+
+                    const lsifFiles = new Set((lsifReferences ? lsifReferences.value : []).map(file))
+
+                    return [
+                        ...(lsifReferences === undefined ? [] : lsifReferences.value),
+                        // Drop fuzzy references from files that have LSIF results.
+                        ...fuzzyReferences.filter(fuzzyRef => !lsifFiles.has(file(fuzzyRef))),
+                    ]
                 },
             })
         )


### PR DESCRIPTION
Original thread https://sourcegraph.slack.com/archives/CHXHX7XAS/p1576271772003500